### PR TITLE
Implement modulus handler for test GET endpoint

### DIFF
--- a/restapi/configure_test_bk.go
+++ b/restapi/configure_test_bk.go
@@ -38,11 +38,13 @@ func configureAPI(api *operations.TestBkAPI) http.Handler {
 
 	api.JSONProducer = runtime.JSONProducer()
 
-	if api.TestGetTestHandler == nil {
-		api.TestGetTestHandler = test.GetTestHandlerFunc(func(params test.GetTestParams) middleware.Responder {
-			return middleware.NotImplemented("operation test.GetTest has not yet been implemented")
-		})
-	}
+	api.TestGetTestHandler = test.GetTestHandlerFunc(func(params test.GetTestParams) middleware.Responder {
+		var result int64
+		if params.ID != nil {
+			result = *params.ID % 2
+		}
+		return test.NewGetTestOK().WithPayload(result)
+	})
 
 	api.PreServerShutdown = func() {}
 


### PR DESCRIPTION
## Summary
- compute `id % 2` in GET /test handler and return result

## Testing
- `go test ./...` *(fails: no required module provides package github.com/go-openapi/loads; to add it: go get github.com/go-openapi/loads)*

------
https://chatgpt.com/codex/tasks/task_e_68a5156c69188332b600c1a80eaa30ea